### PR TITLE
Fix slider init value

### DIFF
--- a/src/classes/remote-slider.ts
+++ b/src/classes/remote-slider.ts
@@ -218,8 +218,6 @@ export class RemoteSlider extends BaseRemoteElement {
 	}
 
 	shouldUpdate(changedProperties: PropertyValues): boolean {
-		const should = super.shouldUpdate(changedProperties);
-
 		if (changedProperties.has('hass')) {
 			const min =
 				parseFloat(
@@ -251,13 +249,14 @@ export class RemoteSlider extends BaseRemoteElement {
 			const vertical =
 				this.renderTemplate(this.config.vertical ?? false) == true;
 
-			if (
+			const rangeChanged =
 				min != this.range[0] ||
 				max != this.range[1] ||
 				step != this.step ||
 				precision != this.precision ||
-				vertical != this.vertical
-			) {
+				vertical != this.vertical;
+
+			if (rangeChanged) {
 				this.range = [min, max];
 				this.step = step;
 				this.precision = precision;
@@ -267,9 +266,14 @@ export class RemoteSlider extends BaseRemoteElement {
 				} else {
 					this.removeAttribute('vertical');
 				}
-				return true;
 			}
+
+			const should = super.shouldUpdate(changedProperties);
+
+			return should || rangeChanged;
 		}
+
+		const should = super.shouldUpdate(changedProperties);
 
 		return (
 			should ||


### PR DESCRIPTION
---
name: Pull request
about: Contribute to this project
title: 'Fix slider init value'
labels:
  - bug
assignees: ''
---

<!--
DO NOT DELETE THIS TEMPLATE.
Or at the very least make sure you include enough information so I know what you're adding.
-->

**Checklist:**

- [x] I've followed [the README contributing guidelines](https://github.com/Nerwyn/universal-remote-card/blob/main/.github/CONTRIBUTING.md) and ensured that pre-commit and build ran correctly.
- [x] I've done by best to ensure that my new code is stylistically similar to the rest of the project.
  - If it isn't too egregious the main developer will fix it in post.
- [x] I've tested that my changes work on my Home Assistant instance, on different browsers and webviews in needed.
- [x] I've ensured that my changes are not causing any new JavaScript errors in the browser console.
- [ ] I've updated the editor to include new fields for new features if needed.
  - The editor is a mess and the main developer is open to working on these changes if needed, but the ability to modify all configuration fields via the editor is a requirement to release the changes.
- [ ] I've updated the README if needed.

**Type of Change:**

- [ ] Default keys, sources, and/or icons
- [x] Bug fix
- [ ] New media platform
- [ ] Extending support for an existing media platform (i.e. keyboard support)
- [ ] New action (e.g. `perform-action`, `toggle`, `navigate`)
- [ ] New interaction (e.g. `tap_action`, `hold_action`)
- [ ] Other

**Description of Changes**

Fixes initial value of slider. When first initializing the widget, the slider set to the volume of a device. Some issues:
- will some times drop to 0, and after a few seconds go to the correct value
- go to 0 and stay there

<!--
Describe the code changes you've made and why you made them.
-->

**Testing Methodology**

Given a basic input config:

```
type: custom:universal-remote-card
custom_actions:
  - type: slider
    name: slider
    range:
      - 0
      - 1
    step: 0.01
    value_attribute: volume_level
    tap_action:
      action: perform-action
      perform_action: media_player.volume_set
      target:
        entity_id: media_player.denon
      data:
        volume_level: "{{ value | float }}"
    entity_id: media_player.denon
rows:
  - slider
media_player_id: media_player.denon
```

With these changes, the widget, when initializing (by force quiting the app, or refreshing the browser), should start at the correct value.

<!--
How did you test your changes?
Did you install the file to your Home Assistant server and ensure that the changes work?

If making default key/source/icon changes, did you test them like above or test them using the card's built in custom actions and icons? (This is fine for this kind of change)

What devices did you test your changes on? Web browsers?
-->

**Additional Information**

Before:

https://github.com/user-attachments/assets/c52c3252-db28-4adf-8cda-a07bba980d6c


After:

https://github.com/user-attachments/assets/9bc7d54b-a5a3-4051-bb3f-8296207fb6da

I needed to bypass the pre-commit hooks because the `npx lint-staged` part was doing something weird and making the whole file have a giant diff.